### PR TITLE
为 ZMQ 方法计算延迟

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ cmake-build-relwithdebinfo/
 *.exe
 *.out
 *.app
-py/audio_player.ipc

--- a/py/.gitignore
+++ b/py/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+audio_player.ipc
+temp

--- a/py/pdm.lock
+++ b/py/pdm.lock
@@ -6,7 +6,7 @@ groups = ["default"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:33cda9711940e89b556888d5a4575ada8bf44d328e5323c8920a514809db10c1"
+content_hash = "sha256:1fc894836f4a33c164f0f2a9f87ea78ee5a08554890547b335c046dc3cb1f539"
 
 [[package]]
 name = "cffi"
@@ -144,4 +144,14 @@ files = [
     {file = "soundfile-0.12.1-py2.py3-none-win32.whl", hash = "sha256:59dfd88c79b48f441bbf6994142a19ab1de3b9bb7c12863402c2bc621e49091a"},
     {file = "soundfile-0.12.1-py2.py3-none-win_amd64.whl", hash = "sha256:0d86924c00b62552b650ddd28af426e3ff2d4dc2e9047dae5b3d8452e0a49a77"},
     {file = "soundfile-0.12.1.tar.gz", hash = "sha256:e8e1017b2cf1dda767aef19d2fd9ee5ebe07e050d430f77a0a7c66ba08b8cdae"},
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.7.1"
+requires_python = ">=3.7"
+summary = "Backported and Experimental Type Hints for Python 3.7+"
+files = [
+    {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
+    {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},
 ]

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "sounddevice>=0.4.6",
     "soundfile>=0.12.1",
     "pyzmq>=25.1.1",
+    "typing-extensions>=4.7.1",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/py/src/video_reader/audio.py
+++ b/py/src/video_reader/audio.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sounddevice as sd
 import soundfile as sf
 import time
+import sys
 
 from typing import TYPE_CHECKING
 
@@ -31,7 +32,7 @@ def read_audio_float32(samples:int):
 
 def read_audio_bytes(samples:int):
     # print("samples", samples)
-    return audio_file.read(samples, dtype='int16').tobytes(), time.time_ns().to_bytes(8, "big") # long long 8 bytes
+    return audio_file.read(samples, dtype='int16').tobytes(), time.time_ns().to_bytes(16, sys.byteorder) # long long 16 bytes
 
 def audio_samples() -> tuple[int, int, int]:
     return audio_file.samplerate, audio_file.frames, audio_file.channels

--- a/py/src/video_reader/audio.py
+++ b/py/src/video_reader/audio.py
@@ -17,7 +17,7 @@ def init_audio(audio_path):
     return audio_file
 
 def audio_finished():
-    print(audio_file.tell(), audio_file.frames)
+    # print(audio_file.tell(), "/", audio_file.frames)
     return audio_file.tell() >= audio_file.frames
 
 def read_audio(samples:int):

--- a/py/src/video_reader/util.py
+++ b/py/src/video_reader/util.py
@@ -1,0 +1,59 @@
+from typing import TypeVar, Generic, Callable
+
+InstanceType = TypeVar("InstanceType", bound="SingletonMeta")
+
+class SingletonMeta(type, Generic[InstanceType]):
+    """
+        元类，使其产生的类变成单例类
+        ```Python
+            from typing_extensions import Self
+            class Test(metaclass=SingletonMeta[Self]): 
+                # Self 用于更好的类型推断
+                pass
+            
+            Test.instance is Test.instance # True
+            Test() is Test() # True
+        ```
+        类中可以定义 `staticmethod`、`classmethod` 装饰的 `instance` 方法来覆盖 `instance` 的创建逻辑
+        ```Python
+            class Test(metaclass=SingletonMeta[Self]):
+                _data = None
+                @classmethod
+                def instance(cls):
+                    if cls._data is None:
+                        cls._data = super().__new__(cls)
+                    return cls._data
+        ```
+    """
+    _instance = None
+    
+    _overridedCls:dict[type, Callable[[],InstanceType]] = {}
+
+    def __new__(meta, name, bases:list[type], attrs:dict):
+        cls = super().__new__(meta, name, bases, attrs)
+        if method := attrs.get("instance"):
+            # 如果 cls 自己定义了 instance
+            if isinstance(method, (staticmethod, classmethod)):
+                # 那个 instance 被定义为上述类的对象
+                # __get__(None, cls)，得到绑定了 cls 的 instance 方法
+                # __get__(None, cls)() 得到装饰函数的返回值
+                meta._overridedCls[cls] = method.__get__(None, cls)
+        elif any(method := meta._overridedCls.get(base) for base in bases):
+            # B 继承于 A，A 定义了 instance，B 没有，那就也用 A 对 instance 的定义
+            meta._overridedCls[cls] = method
+        return cls
+
+
+    @property
+    def instance(cls:type[InstanceType]) -> InstanceType:
+        if method := cls._overridedCls.get(cls):
+            # cls 重写了 instance，优先用重写的
+            return method()
+        if cls._instance is None:
+            cls._instance = super().__call__()
+        return cls._instance
+
+    def __call__(cls):
+        return cls.instance
+
+

--- a/py/src/video_reader/zeromq.py
+++ b/py/src/video_reader/zeromq.py
@@ -255,7 +255,8 @@ class AudioServer(DataServer):
                 data_tuple = read_audio_bytes(self.samplesPreFrame)
                 current_samples += self.samplesPreFrame
                 await self.socket.send_multipart(data_tuple, copy=False)
-                print(int.from_bytes(data_tuple[1], "little"))
+                # print(int.from_bytes(data_tuple[1], "little"))
+                print(f"{current_samples} / {self.totalSamples}")
         except asyncio.TimeoutError:
             print(f"[{self.name}] Timeout")
         finally:

--- a/py/src/video_reader/zeromq.py
+++ b/py/src/video_reader/zeromq.py
@@ -1,93 +1,321 @@
+from __future__ import annotations
+from typing import Callable
+from typing_extensions import Self
 
+import time
 import asyncio
 from enum import Enum
 
 import zmq
-from zmq.asyncio import Context, Socket
-# import signal
+from zmq.asyncio import Context
+from zmq.utils.monitor import recv_monitor_message, _MonitorMessage
 
+from video_reader.util import SingletonMeta
 from video_reader.audio import init_audio, audio_samples, read_audio_bytes, audio_finished, release_audio
 
 class Messages(str, Enum):
-    hello = "HELLO"
-    ok = "OK"
-    ready = "READY"
-    read = "READ"
+    # hello = "HELLO"
+    # ok = "OK"
+    # ready = "READY"
+    # read = "READ"
+    status = "STATUS"
+    """ 客户端询问服务端状态 """
+    get = "GET"
+    """ 需要值 """
+    set = "SET"
+    """ 设置值 """
+    idle = "IDLE"
+    """ 空闲 """
+    playing = "PLAYING"
+    """ 正在播放 """
 
+class ValueName(str, Enum):
+    audio_path = "AUDIO_PATH"
+    audio_info = "AUDIO_INFO"
+    audio_ready = "AUDIO_READY"
+    end = "END"
+    video_path = "VIDEO_PATH"
+    video_info = "VIDEO_INFO"
 
-context = Context()
-socket = context.socket(zmq.PAIR)
+class ValueSlot:
 
-async def wait_path(): # get path
-    recv_task = (socket.recv_string(), ) # tuple
-    while True:
-        print("Sending Hello")
-        await socket.send_string(Messages.hello)  # "HELLO"
-        done, recv_task = await asyncio.wait(recv_task, timeout=1) # 等待 1 秒，如果有结果了会进入 done，否则还是 recv_task
-        if done:
-            message:str = await tuple(done)[0] # 得到消息
-            print("Get Message", message)
-            if message.startswith(Messages.ok):         # "OK {path}"
-                return message.split(maxsplit=1)[1]
+    _value_required:dict[ValueName, ValueSlot] = {}
+    inited = False
 
-async def send_audio_info(path):
-    init_audio(path)
-    sr, samples, channels = audio_samples()
-    await socket.send_string(f"{Messages.ready} {sr} {samples} {channels}") # "READY {sr} {samples} {channels}"
+    def __new__(cls, name):
+        if obj := cls._value_required.get(name):
+            return obj
+        return super().__new__(cls)
 
-async def on_init():
-    path = await wait_path()
-    await send_audio_info(path)
+    def __init__(self, name:ValueName):
+        if not self.inited:
+            print("Add Slot:", name)
+            self.name = name
+            self._future = asyncio.Future()
+            self._value_required[name] = self
+            if ServerManager().status.value < ServerStatus.NeedValue.value:
+                ServerManager().status = ServerStatus.NeedValue
+            self.inited = True
 
-async def send_audio():
-    try:
-        while (message := await asyncio.wait_for(socket.recv_string(), timeout=5)):  # 5 秒超时
-            if message.startswith(Messages.read):
-                samples = int(message.split(maxsplit=1)[1])  # "READ {samples}"
-                print("Asked to Read", samples, "samples")
-                data_tuple = read_audio_bytes(samples)  # data, time_ns (bytes)
-                await socket.send_multipart(data_tuple, copy=False)
-                if audio_finished():
-                    release_audio()
-                    print("Audio Finished")
+    @classmethod
+    async def ask_for(cls, name:ValueName):
+        return await cls(name).get()
+
+    async def get(self):
+        if not self.had_value():
+            await self._future
+        return self._future.result()
+
+    def set(self, value):
+        self._future.set_result(value)
+
+    def had_value(self):
+        return self._future.done()
+
+class MessageServer:
+
+    LISTEN_ALL_EVENTS = -1
+    event_names:dict[int, str] = { getattr(zmq, name):name for name in dir(zmq) if name.startswith("EVENT_") }
+    event_names[LISTEN_ALL_EVENTS] = "LISTEN_ALL_EVENTS"
+    # event_id : name
+
+    def __init__(self):
+        self.context = Context()
+        self.socket = self.context.socket(zmq.REP)  # 接收消息
+        self._on_socket_evnets:dict[int, Callable[[_MonitorMessage], None]] = {}
+
+    async def init(self):
+        print("[Message Server] Initializing...")
+        self.socket.bind("ipc://temp/message.ipc")
+        print("[Message Server] Ready!")
+
+    async def listen(self):
+        print("[Message Server] Start Listening...")
+        try:
+            while not ServerManager()._stop_event.is_set():
+                message = await self.socket.recv_string()
+                await self.handle_message(message)
+        except asyncio.TimeoutError:
+            print("[Message Server] Listening Timeout")
+        finally:
+            print("[Message Server] Listening Stopped")
+
+    async def life_cycle(self):
+        print("[Message Server] Getting Event Monitor...")
+        monitor = self.socket.get_monitor_socket()
+        try:
+            while await monitor.poll() and not ServerManager()._stop_event.is_set():
+                event = await recv_monitor_message(monitor)
+                self.emit_event(event)
+                if event["event"] == zmq.EVENT_MONITOR_STOPPED:
                     break
-        # print(repr(message))
-    except asyncio.TimeoutError:
-        print("Ask for Reading Timeout")
+        except asyncio.TimeoutError:
+            print("[Message Server] Event Monitor Timeout")
+        finally:
+            monitor.close()
+            print("[Message Server] Event Monitor Stopped")
 
-# def registerSignal():
-#     sigMap = {signal.SIGTERM:"SIGTERM", signal.SIGINT:"SIGINT"}
+    def emit_event(self, event:_MonitorMessage):
+        event_id = event["event"]
+        print("[Message Server] Received", self.event_names[event_id])
+        if func := self._on_socket_evnets.get(event_id):
+            func(event)
 
-#     def callback(sig:int,frame=None):
-#         print(f"检测到 {sigMap[sig]}")
-#         import sys
-#         sys.exit(0)
+    def on_event(self, event_id:int=None):
+        if event_id is None:
+            event_id = self.LISTEN_ALL_EVENTS
+        def inner(func):
+            self._on_socket_evnets[event_id] = func
+            return func
+        return inner
 
-#     try:
-#         loop = asyncio.get_event_loop()
-#         for sig in sigMap:
-#             loop.add_signal_handler(sig,callback,sig)
-#     except NotImplementedError:
-#         for sig in sigMap:
-#             signal.signal(sig,callback)
+    async def run(self):
+        await self.init()
+        life_cycle = asyncio.create_task(self.life_cycle())
+        listen = asyncio.create_task(self.listen())
+        await ServerManager()._stop_event.wait()  # 最好能正常结束
+        print("[Message Server] Stopping...")
+        print("[Message Server] Ending Tasks...")
+        for task in asyncio.as_completed((life_cycle, listen), timeout=5):
+            try:
+                await task
+            except asyncio.TimeoutError:
+                pass
+        print("[Message Server] Server Stopped")
 
-async def main():
-    # registerSignal()
+    async def handle_message(self, message:str):
+        print("[Message Server] Received Message:", message)
+        if not (response := await self.message_response(message)):
+            response = self.default_response()  # recv 之后一定要 send
+        await self.socket.send_string(response)
+        print("[Message Server] Responded:", response)
 
-    print("ZeroMQ version", zmq.zmq_version())
-    print("Connecting to the audio server...")
-    # socket.connect("ipc://audio_player.ipc")
-    socket.connect("ipc://temp/audio_player.ipc")
-    # socket.connect("tcp://localhost:5555")
+    async def message_response(self, message:str):
+        if message.startswith(Messages.status):
+            return self.status_response(self.unprefix(message, Messages.status))
+        if message.startswith(Messages.set):
+            return self.set_value_response(self.unprefix(message, Messages.set))
+        if message.startswith(Messages.get):
+            return await self.get_value_response(self.unprefix(message, Messages.get))
 
-    await on_init()
-    print("Ready!")
+    def status_response(self, message:str):
+        manager = ServerManager()
+        if manager.status == ServerStatus.NeedValue:
+            if ValueSlot._value_required:
+                # GET {ValueName1} {ValueName2} ...
+                return f'{Messages.get} {" ".join(name for name, slot in ValueSlot._value_required.items() if not slot.had_value())}' 
+        if manager.status == ServerStatus.Playing:
+            return Messages.playing
 
-    print("Sending...")
+    def set_value_response(self, message:str):
+        values = message.split()
+        for name, val in zip(values[::2], values[1::2]):  # {name1} {value1} {name2} {value2}...
+            if slot := ValueSlot._value_required.get(name):
+                slot.set(val)
 
-    await send_audio()
+    async def get_value_response(self, message:str):
+        names = message.split() # {name1} {name2}...
+        slots = [ slot for name in names if (slot := ValueSlot._value_required.get(name)) ]
+        values = await asyncio.gather(*(slot.get() for slot in slots))
+        name_values = " ".join(f"{slot.name} {value}" for slot, value in zip(slots, values))
+        return f'{Messages.set} {name_values}'
+                
+    @staticmethod
+    def default_response():
+        return Messages.idle
+    
+    @staticmethod
+    def unprefix(message:str, prefix:Messages):
+        return message.removeprefix(prefix).strip()
 
-    print("Finished")
+class DataServer:
+
+    def __init__(self, endpoint:str):
+        self.context = Context()
+        self.socket = self.context.socket(zmq.PUB)  # 广播数据
+        self.endpoint = endpoint
+
+    @property
+    def name(self):
+        return "Data Server"
+
+    async def init(self):
+        print(f"[{self.name}] Initializing...")
+        self.socket.bind(self.endpoint)
+        print(f"[{self.name}] Ready!", self.endpoint)
+
+    async def run(self):
+        await self.init()
+        await self.ask_for_values()
+        await self.send_data()
+        print(f"[{self.name}] Server Stopped")
+
+    async def ask_for_values(self):
+        raise NotImplementedError
+
+    async def send_data(self):
+        raise NotImplementedError
+
+class AudioServer(DataServer):
+    
+    samplesPreFrame = 1024
+    readThreshold = 2048
+
+    def __init__(self):
+        super().__init__("ipc://temp/audio_publish.ipc")
+
+    @property
+    def name(self):
+        return "Audio Server"
+    
+    async def ask_for_values(self):
+        print(f"[{self.name}] Asking for Path")
+        self.audio_path:str = await ValueSlot.ask_for(ValueName.audio_path)
+        print(f"[{self.name}] Reading Audio Information")
+        init_audio(self.audio_path)
+        self.sr, self.totalSamples, self.channels = audio_samples()
+        ValueSlot(ValueName.audio_info).set(f"{self.sr}|{self.totalSamples}|{self.channels}") # 三个数字一起发送
+        ready_task = asyncio.create_task(ValueSlot.ask_for(ValueName.audio_ready))
+        ServerManager().status = ServerStatus.Playing
+        await ready_task
+        print(f"[{self.name}] Ready to Send")
+
+    async def send_data(self):
+        # ServerManager().status = ServerStatus.Playing
+        print(f"[{self.name}] Start Sending")
+        current_samples = 0
+        start_time = time.time()
+        sleepTime = (self.samplesPreFrame / self.sr) / 10
+        try:
+            while not audio_finished() and not ServerManager()._stop_event.is_set():
+                current_time = time.time()
+                if (current_time - start_time) * self.sr < current_samples - self.readThreshold:
+                    await asyncio.sleep(sleepTime)
+                    continue
+                data_tuple = read_audio_bytes(self.samplesPreFrame)
+                current_samples += self.samplesPreFrame
+                await self.socket.send_multipart(data_tuple, copy=False)
+                print(int.from_bytes(data_tuple[1], "little"))
+        except asyncio.TimeoutError:
+            print(f"[{self.name}] Timeout")
+        finally:
+            release_audio()
+            print(f"[{self.name}] Released")
+
+class ServerStatus(Enum):
+    Idle = 0
+    NeedValue = 1
+    Playing = 2
+
+class ServerManager(metaclass=SingletonMeta[Self]):
+
+    def __init__(self):
+        # print("Server Manager Init")
+        self.status:ServerStatus = ServerStatus.Idle
+        self._stop_event = asyncio.Event()
+
+    async def run(self):
+        print("ZeroMQ version", zmq.zmq_version())
+        self.register_signal()
+        self.message_server = MessageServer()
+        message_task = asyncio.create_task(self.message_server.run())
+        self.audio_server = AudioServer()
+        audio_task = asyncio.create_task(self.audio_server.run())
+        await ValueSlot.ask_for(ValueName.end)
+        self._stop_event.set()
+        await self._stop_event.wait()
+        print("Stop Event is Set")
+        await asyncio.gather(message_task, audio_task)
+        print("All Server Stopped")
+
+    def register_signal(self):
+        import signal
+        sigMap={signal.SIGTERM:"SIGTERM", signal.SIGINT:"SIGINT"}
+                # signal.CTRL_BREAK_EVENT:"CTRL_BREAK_EVENT", signal.CTRL_C_EVENT:"CTRL_C_EVENT",
+                # signal.SIGBREAK:"SIGBREAK"}
+
+        def callback(sig:int,frame=None):
+            print(f"检测到 {sigMap[sig]}")
+            self._stop_event.set()
+        
+        try:
+            loop=asyncio.get_event_loop()
+            for sig in sigMap:
+                loop.add_signal_handler(sig, callback, sig)
+        except NotImplementedError:
+            for sig in sigMap:
+                signal.signal(sig,callback)
+
+        import platform
+        if platform.system() == "Windows":
+            from zmq.utils.win32 import allow_interrupt
+            def callback():
+                print(f"检测到中断")
+                self._stop_event.set()
+                    
+            allow_interrupt(callback).__enter__() # 感觉像强行掐断了，没触发回调函数
+
+main = ServerManager().run
 
 if __name__ == "__main__":
 

--- a/py/src/video_reader/zeromq_pair.py
+++ b/py/src/video_reader/zeromq_pair.py
@@ -1,0 +1,99 @@
+
+import asyncio
+from enum import Enum
+
+import zmq
+from zmq.asyncio import Context
+# import signal
+
+from video_reader.audio import init_audio, audio_samples, read_audio_bytes, audio_finished, release_audio
+
+class Messages(str, Enum):
+    hello = "HELLO"
+    ok = "OK"
+    ready = "READY"
+    read = "READ"
+
+
+context = Context()
+socket = context.socket(zmq.PAIR)
+
+async def wait_path(): # get path
+    recv_task = (socket.recv_string(), ) # tuple
+    while True:
+        print("Sending Hello")
+        await socket.send_string(Messages.hello)  # "HELLO"
+        done, recv_task = await asyncio.wait(recv_task, timeout=1) # 等待 1 秒，如果有结果了会进入 done，否则还是 recv_task
+        if done:
+            message:str = await tuple(done)[0] # 得到消息
+            print("Get Message", message)
+            if message.startswith(Messages.ok):         # "OK {path}"
+                return message.split(maxsplit=1)[1]
+
+async def send_audio_info(path):
+    init_audio(path)
+    sr, samples, channels = audio_samples()
+    await socket.send_string(f"{Messages.ready} {sr} {samples} {channels}") # "READY {sr} {samples} {channels}"
+
+async def on_init():
+    path = await wait_path()
+    await send_audio_info(path)
+
+async def send_audio():
+    try:
+        while (message := await asyncio.wait_for(socket.recv_string(), timeout=5)):  # 5 秒超时
+            if message.startswith(Messages.read):
+                samples = int(message.split(maxsplit=1)[1])  # "READ {samples}"
+                print("Asked to Read", samples, "samples")
+                data_tuple = read_audio_bytes(samples)  # data, time_ns (bytes)
+                # print(int.from_bytes(data_tuple[1], "little"))
+                await socket.send_multipart(data_tuple, copy=False)
+                if audio_finished():
+                    release_audio()
+                    print("Audio Finished")
+                    break
+        # print(repr(message))
+    except asyncio.TimeoutError:
+        print("Ask for Reading Timeout")
+
+# def registerSignal():
+#     sigMap = {signal.SIGTERM:"SIGTERM", signal.SIGINT:"SIGINT"}
+
+#     def callback(sig:int,frame=None):
+#         print(f"检测到 {sigMap[sig]}")
+#         import sys
+#         sys.exit(0)
+
+#     try:
+#         loop = asyncio.get_event_loop()
+#         for sig in sigMap:
+#             loop.add_signal_handler(sig,callback,sig)
+#     except NotImplementedError:
+#         for sig in sigMap:
+#             signal.signal(sig,callback)
+
+async def main():
+    # registerSignal()
+
+    print("ZeroMQ version", zmq.zmq_version())
+    print("Connecting to the audio server...")
+    # socket.connect("ipc://audio_player.ipc")
+    socket.connect("ipc://temp/audio_player.ipc")
+    # socket.connect("tcp://localhost:5555")
+
+    await on_init()
+    print("Ready!")
+
+    print("Sending...")
+
+    await send_audio()
+
+    print("Finished")
+
+if __name__ == "__main__":
+
+    import platform
+    if platform.system() == "Windows":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    
+    asyncio.run(main())

--- a/py/tests/zeromq.py
+++ b/py/tests/zeromq.py
@@ -1,0 +1,102 @@
+
+import zmq
+from zmq.asyncio import Context, Socket
+
+import sounddevice as sd
+
+import asyncio
+
+values = {
+    "AUDIO_PATH": "../resource/audio.mp3",
+}
+
+async def message_client():
+    m_context = Context()
+    m_socket = m_context.socket(zmq.REQ)
+
+    m_socket.connect("ipc://temp/message.ipc")
+
+    sr, samples, channels = None, None, None
+    audio_task = None
+    ready = asyncio.Event()
+
+    await m_socket.send_string("STATUS")
+    while message := await m_socket.recv_string():
+        print(message)
+        if message == "IDLE":
+            await m_socket.send_string("STATUS")
+            continue
+        if message == "PLAYING":
+            if not sr:
+                await m_socket.send_string(f'GET AUDIO_INFO')   
+            elif not audio_task:
+                audio_task = asyncio.create_task(audio_client(sr, samples, channels, ready))
+                await ready.wait()
+                await m_socket.send_string("SET AUDIO_READY TRUE")
+            else:
+                await audio_task
+                await m_socket.send_string(f'SET END TRUE')
+                break
+            continue
+        if message.startswith("GET"):
+            res = []
+            for name in message.removeprefix("GET ").split():
+                if value := values.get(name):
+                    print(name, ":", value)
+                    res.append(f"{name} {value}")
+            await m_socket.send_string(f'SET {" ".join(res)}')
+            continue
+        if message.startswith("SET"):
+            name_values = message.removeprefix("SET ").split()
+            for name, value in zip(name_values[::2], name_values[1::2]):
+                if name == "AUDIO_INFO":
+                    sr, samples, channels = [int(num) for num in value.split("|")]
+            await m_socket.send_string("STATUS")
+            continue
+    print("Client End")
+
+import numpy as np
+from collections import deque
+
+buffer = deque()
+
+def read_audio():
+    if buffer:
+        return buffer.popleft()
+    
+
+def callback(outdata:np.ndarray, frames:int, time_, status):
+    samples = read_audio()
+    if samples is not None:
+        outdata[:] = samples
+    else:
+        outdata.fill(0)
+
+async def audio_client(sr:int, total_samples:int, channels:int, ready:asyncio.Event):
+    print("audio_client", sr, total_samples, channels)
+    a_context = Context()
+    a_socket = a_context.socket(zmq.SUB)
+    a_socket.connect("ipc://temp/audio_publish.ipc")
+    a_socket.setsockopt(zmq.SUBSCRIBE, b'')
+    with sd.OutputStream(sr, channels=channels, blocksize=1024, callback=callback, dtype="int16") as stream:
+        values["AUDIO_READY"] = "TRUE"
+        ready.set()
+        print("wait for recv_multipart")
+        try:
+            while datas := await asyncio.wait_for(a_socket.recv_multipart(), timeout=5):
+                buffer.append(np.frombuffer(datas[0], dtype="int16").reshape((-1,2)))
+                print(int.from_bytes(datas[1], "little"))
+        except asyncio.TimeoutError:
+            print("Read Timeout")
+        while buffer:
+            print(len(buffer))
+            await asyncio.sleep(1)
+            
+
+
+import platform
+if platform.system() == "Windows":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+asyncio.run(message_client())
+

--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -31,7 +31,7 @@ int AudioPlayer::init(int sampleRate, int channels) {
 	std::cout << "Format Sampling Rate: " << format.sampleRate() << std::endl;
 	
 	sink = new QAudioSink(device, format, this);
-    sink->setBufferSize(96000);
+	sink->setBufferSize(sampleRate * 2);  // 暂时设成采样率的 2 倍 sr 48000 buffer 96000
 	audioIO = sink->start();
 
 	std::cout << "Buffer Size: " << sink->bufferSize() << std::endl;
@@ -43,9 +43,9 @@ int AudioPlayer::init(int sampleRate, int channels) {
 
 void AudioPlayer::readData(const char* data, size_t size, long long timeNs) {
 	std::cout << "Reading " << size << " Bytes" << std::endl;
-	//QByteArray audioData(data, size);
-	//audioIO->write(audioData);
-	audioIO->write(data, size);
+	QByteArray audioData(data, size);
+	audioIO->write(audioData);
+	//audioIO->write(data, size);
 }
 
 

--- a/src/AudioPlayer.cpp
+++ b/src/AudioPlayer.cpp
@@ -37,15 +37,22 @@ int AudioPlayer::init(int sampleRate, int channels) {
 	std::cout << "Buffer Size: " << sink->bufferSize() << std::endl;
 	std::cout << "AudioSink is Ready" << std::endl;
 
+	totalLatency = 0;
 	//emit AudioPlayer::startRead();
 	return 0;
 }
 
-void AudioPlayer::readData(const char* data, size_t size, long long timeNs) {
+void AudioPlayer::readData(const char* data, size_t size, std::chrono::nanoseconds timeNsPY, long readTimes) {
 	std::cout << "Reading " << size << " Bytes" << std::endl;
 	QByteArray audioData(data, size);
 	audioIO->write(audioData);
 	//audioIO->write(data, size);
+	auto now = std::chrono::system_clock::now();
+	auto timeNs = std::chrono::time_point_cast<std::chrono::nanoseconds>(now).time_since_epoch();
+	totalLatency += (timeNs - timeNsPY).count();
+	if (readTimes) {
+		std::cout << "[Latency (ns)] Total: " << totalLatency << " \tAverage: " << totalLatency / readTimes << " \treadTimes: " << readTimes << std::endl;
+	}
 }
 
 

--- a/src/AudioPlayer.h
+++ b/src/AudioPlayer.h
@@ -14,12 +14,15 @@ public:
 	QAudioSink* sink = nullptr;
 	QIODevice* audioIO = nullptr;
 
+	long long totalLatency = 0;
+
 public slots:
 	int init(int sampleRate, int channels);
-	void readData(const char* data, size_t size, long long timeNs);
+	void readData(const char* data, size_t size, std::chrono::nanoseconds timeNsPY, long readTimes);
 
 signals:
 	void startRead();
+
 };
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,7 @@ find_package(Qt6 COMPONENTS Core Widgets Gui Multimedia REQUIRED )
 find_package(cppzmq)
 
 # 生成可执行文件
-add_executable(${PROJECT_NAME} main.cpp VideoWidget.cpp Plugin.cpp PyAPIPlugin.cpp PluginManager.cpp ZeroMQPlugin.cpp AudioPlayer.cpp QZeroMQServer.cpp)
+add_executable(${PROJECT_NAME} main.cpp VideoWidget.cpp Plugin.cpp PyAPIPlugin.cpp PluginManager.cpp ZeroMQPlugin.cpp AudioPlayer.cpp QZeroMQServer.cpp ZeroMQPairPlugin.cpp)
 
 # 链接头文件和库
 # include_directories(${PYTHON_INCLUDE_DIRS})

--- a/src/PyAPIPlugin.cpp
+++ b/src/PyAPIPlugin.cpp
@@ -434,7 +434,7 @@ int PyAPIPlugin::run() {
 		std::cout << "Thread Starting" << std::endl;
 		//QAudioOutput audioOutput(device, format);
 		QAudioSink audioSink(device, format);
-        audioSink.setBufferSize(96000);
+        audioSink.setBufferSize(sampleRate * 2);  // 暂时设成采样率的 2 倍 sr 48000 buffer 96000
 		//QIODevice* audioIO = audioOutput.start();
 		QIODevice* audioIO = audioSink.start();
 		Py_BEGIN_ALLOW_THREADS

--- a/src/QZeroMQServer.cpp
+++ b/src/QZeroMQServer.cpp
@@ -28,7 +28,7 @@ void QZeroMQServer::serve() {
     zmq::context_t context(2);
     zmq::socket_t socket(context, zmq::socket_type::pair);
     std::cout << "Setting up audio server..." << std::endl;
-    socket.bind("ipc://../py/audio_player.ipc");
+    socket.bind("ipc://../py/temp/audio_player.ipc");
     //socket.bind("tcp://localhost:5555");
 
     const char* audio_path = "../resource/audio.mp3";
@@ -77,9 +77,9 @@ void QZeroMQServer::serve() {
     
     long long readSamples = 0;
     long long currentTimeSec = 0;
-    long samplesPreRead = sampleRate / 8;
-    const long readThreshold = samplesPreRead / 2;
-    const long sleepMs = 1000 / 30;
+    long samplesPreRead = sampleRate / 16;
+    const long readThreshold = sampleRate / 2;
+    const long sleepMs = 1000 / 16;
 
     AudioPlayer audioPlayer;
     QThread audioThread;
@@ -108,7 +108,7 @@ void QZeroMQServer::serve() {
     std::cout << "Start Reading..." << std::endl;
 
     std::string readString = "READ ";
-    readString.append(std::to_string(samplesPreRead)); // "OK {audio_path}"
+    readString.append(std::to_string(samplesPreRead)); // "READ {audio_path}"
     zmq::recv_result_t readResult;
 
     auto startTime = std::chrono::system_clock::now();

--- a/src/QZeroMQServer.h
+++ b/src/QZeroMQServer.h
@@ -19,7 +19,7 @@ public slots:
 
 signals:
 	int init(int sampleRate, int channels);
-	void readData(const char* data, size_t size, long long timeNs);
+	void readData(const char* data, size_t size, std::chrono::nanoseconds timeNsPY, long readTimes);
 
 private:
 	bool readyToRead = false;

--- a/src/ZeroMQPairPlugin.cpp
+++ b/src/ZeroMQPairPlugin.cpp
@@ -1,0 +1,47 @@
+#include <iostream>
+#include <chrono>
+#include <thread>
+
+#include <QThread>
+
+#include "ZeroMQPairPlugin.h"
+#include "QZeroMQServer.h"
+
+ZeroMQPairPlugin::ZeroMQPairPlugin(QApplication* _app) : app(_app) {}
+
+int ZeroMQPairPlugin::run()
+{
+    QZeroMQServer server;
+    QThread audioThread;
+    QThread* serverThread = QThread::create([&]() {
+        server.serve();
+        });
+    server.moveToThread(serverThread);
+    
+
+
+    //while (true) {
+    //    zmq::message_t request;
+
+    //    //  Wait for next request from client
+    //    socket.recv (request, zmq::recv_flags::none);
+    //    std::cout << "Received Hello" << std::endl;
+
+    //    //  Do some 'work'
+    //    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    //    //  Send reply back to client
+    //    zmq::message_t reply (5);
+    //    memcpy (reply.data (), "World", 5);
+    //    socket.send (reply, zmq::send_flags::none);
+    //}
+
+    serverThread->start();
+
+    int ret = app->exec();
+
+    serverThread->wait();
+
+    return ret;
+}
+

--- a/src/ZeroMQPairPlugin.h
+++ b/src/ZeroMQPairPlugin.h
@@ -1,0 +1,20 @@
+#ifndef ZEROMQPAIRPLUGIN_H
+#define ZEROMQPAIRPLUGIN_H
+
+#include <QApplication>
+
+#include "Plugin.h"
+
+class ZeroMQPairPlugin : public Plugin
+{
+
+public:
+	ZeroMQPairPlugin(QApplication* app);
+
+	int run();
+
+private:
+	QApplication* app;
+};
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,14 +2,16 @@
 
 #include "PyAPIPlugin.h"
 #include "ZeroMQPlugin.h"
+#include "ZeroMQPairPlugin.h"
 #include "PluginManager.h"
 
 
 int main(int argc, char *argv[]) {
 	QApplication app(argc, argv);
 
-//    PyAPIPlugin plugin = PyAPIPlugin(&app);
-	ZeroMQPlugin plugin = ZeroMQPlugin(&app);
+    //PyAPIPlugin plugin = PyAPIPlugin(&app);
+	//ZeroMQPlugin plugin = ZeroMQPlugin(&app);
+	ZeroMQPairPlugin plugin = ZeroMQPairPlugin(&app);
 	PluginManager pm(&plugin);
 	
 	int ret = pm.run();


### PR DESCRIPTION
还有一些别的更改，比如让缓冲区是采样率的 2 倍、修改 ipc 位置

顺便为 py 那边加了超时，使服务端关闭时客户端能在稍后退出

其实感觉目前用的计时逻辑有点问题，或许应该更多地使用 std::chrono