### PR TITLE
修复 ZeroMQPair

### DIFF
--- a/src/QZeroMQServer.cpp
+++ b/src/QZeroMQServer.cpp
@@ -34,7 +34,7 @@ void QZeroMQServer::serve() {
     {
         std::cout << "Receiving Hello..." << std::endl;
         helloResult = socket.recv(helloMsg);
-        if (!(helloResult.has_value() && helloMsg.to_string_view().find("HELLO ") == 0)) {
+        if (!(helloResult.has_value() && helloMsg.to_string_view().find("HELLO") == 0)) {
             //std::this_thread::sleep_for(std::chrono::seconds(1));  // 每秒尝试一次
             QThread::sleep(1);
             continue;


### PR DESCRIPTION
不知道为啥之前改错了
这个要 C++ 先启动，然后 python 那边启动